### PR TITLE
accommodate existing query when adding query params

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # To test on latest Rails release, use the following:
 gem 'rails'
 gem 'minitest'
+gem 'addressable'
 
 # To test on Rails 4.0.x release, use the following e.g. for 4.0.1:
 # gem 'rails', '= 4.0.1'

--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -119,19 +119,17 @@ module RailsAutolink
                 href_with_params = href
                 if options[:params]
                   found_a_match = true
+                  uri = Addressable::URI.parse(href)
                   if options[:domains_for_params]
                     found_a_match = false
-                    uri = URI.parse(href)
                     options[:domains_for_params].each do |domain|
                       found_a_match = true if uri.host.downcase.include? domain.downcase
                     end
                   end
                   if found_a_match
-                    params = options[:params].to_query
-                    if false == options[:sanitize]
-                      params = CGI.escapeHTML params
-                    end
-                    href_with_params += "?#{params}"
+                    uri.query_values = (uri.query_values || {}).merge(options[:params])
+                    uri.query = CGI.escapeHTML uri.query
+                    href_with_params = uri.to_s
                   end
                 end
 

--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -127,6 +127,7 @@ module RailsAutolink
                     end
                   end
                   if found_a_match
+                    uri.query = CGI.unescapeHTML(uri.query) if uri.query
                     uri.query_values = (uri.query_values || {}).merge(options[:params])
                     uri.query = CGI.escapeHTML uri.query
                     href_with_params = uri.to_s

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -392,7 +392,7 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
       ' <a href="http://example.com/foo?a=1&amp;b=http%3A%2F%2Fjjb.cc%2F&amp;c=M%26M">' +
       'http://example.com/foo?a=1</a>' +
       ' <a href="http://example.com?a=1&amp;b=http%3A%2F%2Fjjb.cc%2F&amp;c=M%26M&amp;z=2">' +
-      'http://example.com?a=1&z=2</a>' +
+      'http://example.com?a=1&amp;z=2</a>' +
       ' goodbye'
     assert_equal(
       output,

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -12,6 +12,7 @@ require 'action_view/helpers'
 require 'action_dispatch/testing/assertions'
 require 'timeout'
 require "rails_autolink/helpers"
+require "addressable/uri"
 
 class TestRailsAutolink < MiniTest::Unit::TestCase
   include ActionView::Helpers::CaptureHelper
@@ -381,6 +382,21 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     assert_equal(
       output,
       auto_link(text, :params => {:a => 1}, :domains_for_params => %w[foo.com bar.com])
+    )
+  end
+
+  def test_auto_link_recognizes_existing_params_when_appending_new_params
+    text = "hello http://example.com/foo?a=1 http://example.com?a=1&z=2 goodbye"
+    output =
+      'hello' +
+      ' <a href="http://example.com/foo?a=1&amp;b=http%3A%2F%2Fjjb.cc%2F&amp;c=M%26M">' +
+      'http://example.com/foo?a=1</a>' +
+      ' <a href="http://example.com?a=1&amp;b=http%3A%2F%2Fjjb.cc%2F&amp;c=M%26M&amp;z=2">' +
+      'http://example.com?a=1&z=2</a>' +
+      ' goodbye'
+    assert_equal(
+      output,
+      auto_link(text, :params => {:b => "http://jjb.cc/", :c => "M&M"})
     )
   end
 


### PR DESCRIPTION
use addressable gem to add params to existing query string

NB addressable puts params in alphabetical order by default
